### PR TITLE
Add ndarray release + link to discussions

### DIFF
--- a/drafts/2024-09.md
+++ b/drafts/2024-09.md
@@ -42,10 +42,11 @@ and compute their values and derivatives. ndgrid is a library for handling finit
 In its first release, ndgrid supports grids of interval, triangle, and quadrilataral cells stored
 in serial or in parallel, with parallel mesh partitioning carried out using [coupe](https://crates.io/crates/coupe).
 
-### [ndarray v0.16.1](https://crates.io/crates/ndarray)
-ndarray implements an n-dimensional container for general elements and for numerics.
-This release mainly includes some refactors and bug fixes (see the [full release notes](https://github.com/rust-ndarray/ndarray/releases/tag/0.16.1)
-for more details).
+### [ndarray v0.16.0](https://crates.io/crates/ndarray)
+Ndarray implements an n-dimensional container for general elements and for numerics.
+Ndarray had its long outstanding v0.16.0 release recently which brought some larger changes and many bugfixes. Ndarray has since also followed up with some minor fixes in v0.16.1.
+See the full release notes: [v0.16.0](https://github.com/rust-ndarray/ndarray/releases/tag/0.16.0), [v0.16.1](https://github.com/rust-ndarray/ndarray/releases/tag/0.16.1)
+for more details.
 
 ## Events
 <!--

--- a/drafts/2024-09.md
+++ b/drafts/2024-09.md
@@ -42,6 +42,11 @@ and compute their values and derivatives. ndgrid is a library for handling finit
 In its first release, ndgrid supports grids of interval, triangle, and quadrilataral cells stored
 in serial or in parallel, with parallel mesh partitioning carried out using [coupe](https://crates.io/crates/coupe).
 
+### [ndarray v0.16.1](https://crates.io/crates/ndarray)
+ndarray implements an n-dimensional container for general elements and for numerics.
+This release mainly includes some refactors and bug fixes (see the [full release notes](https://github.com/rust-ndarray/ndarray/releases/tag/0.16.1)
+for more details).
+
 ## Events
 <!--
 This section can be used to advertise events. Items should be sorted in date order, with
@@ -79,3 +84,13 @@ order in which they are added and should use the format:
 <!--
 Any items that do not fit into any other section can be added here.
 -->
+
+### ndarray maintainership roundtable and design discussions
+
+Discussions are currently taking place around how to reinforce the maitainership of ndarray, as well as
+ndarray-linalg and ndarray-stats. There are also some ongoing discussions to re-think some of the design
+decisions, with a desire to build a common base for ndspans or ndarrays in Rust more broadly, not limited
+to the ndarray crate itself.
+
+If you would like to join in, head over to the [github issue](https://github.com/rust-ndarray/ndarray/issues/1272)
+and/or join the Zulip chat mentioned in the issue!


### PR DESCRIPTION
I added the latest ndarray release as well as a call for contributions around the discussions that are currently taking place around the ndarray ecosystem.

I thought it might be preferable to separate the two, although they are related.