### PR TITLE
add integraal 0.1.0 release entry

### DIFF
--- a/drafts/2024-11.md
+++ b/drafts/2024-11.md
@@ -36,6 +36,19 @@ be sorted in alphabetical order and should use the format:
 <brief description of the library and its new features in this release>
 -->
 
+### [integraal 0.1.0](https://crates.io/crates/integraal)
+
+The `integraal` crate features a main structure that acts as the entrypoint for your integral computations. You can
+specify the domain and the function of the integral, as well as the approximation rule using methods of the structure.
+It follows a builder-like pattern.
+
+Domains and functions are described using struct enums for the sake of flexibility. The repository contains
+usage examples for both analytical expression and sampled values integration. Multiple numerical integration methods
+are implemented, each having different requirements and dependencies. All of this is detailed in the documentation.
+
+In the future, the computation kernel may support different execution backends. This would align with the initial
+motivation behind this crate, that is being an experiment over flexible API designs for HPC.
+
 ## Events
 <!--
 This section can be used to advertise events. Items should be sorted in date order, with


### PR DESCRIPTION
I added a release note for a numerical integration crate I'm working on. 

The description is slightly longer than what I've seen on previous issues; I can shorten it if needed, but I wanted to properly introduce the crate for its first (real) release. I believe I didn't mess up the format, but feel free to correct it / ask for revisions.