### PR TITLE
Add job offers in Aachen (Wittkowski group)

### DIFF
--- a/drafts/2025-04.md
+++ b/drafts/2025-04.md
@@ -69,6 +69,32 @@ order in which they are added and should use the format:
 <description of job, including how to apply and deadline>
 -->
 
+### [PhD positions, Postdoc positions, Software developers, and Fellowship-funded research stays, Aachen (Germany)](https://www.dwi.rwth-aachen.de/en/job-offer/computer-simulations-and-theory-various-topics)
+
+There is a [new research group](https://www.dwi.rwth-aachen.de/en/working-group/rg-wittkowski) at the DWI - Leibniz Institute for Interactive Materials in Aachen and the Department of Physics at RWTH Aachen University (Germany). Its current research projects are
+- Sound-propelled microrobots
+- Ultrasound-controlled 3D-bioprinting
+- Computational fluid dynamics simulations
+- Acoustofluidics
+- Microfluidics
+- Light-propelled microparticles
+- Intelligent matter and artificial neural networks
+
+There will be opportunities for
+- PhD positions
+- Postdoc positions
+- Fellowship-funded research stays
+- Scientists and software developers
+
+The group is mainly looking for researchers who are talented and experienced in 
+- Computer simulations  
+- Programming
+- Software development
+
+In recent years, the group has used Rust extensively to create new high-performance simulation software (see for example [this talk](https://www.youtube.com/watch?v=QbUmxxdz_Cc) at the last SciComp Rust workshop).
+
+If you are interested in one of these research projects and would like to work in this group, please have a look at the group's [webpage](https://www.dwi.rwth-aachen.de/en/working-group/rg-wittkowski) and follow the instructions mentioned there for applying for writing a thesis in the group or for applying for a position in the group.
+
 ## Studentships
 <!--
 This section can be used to advertise studentships (eg PhDs, Master's programmes) that may be of interest.


### PR DESCRIPTION
Hi,

I have added job offers for a new research group in Aachen. Since the group uses Rust fairly extensively (see the talks of Adrian and myself at the SciComp Rust workshops), I thought this might be interesting for the newsletter subscribers.

Just to avoid confusion: The group is "new" in the sense that until very recently it was based in Münster (also Germany), but has now moved to Aachen.