### PR TITLE
`event`: Add RustMeet conf (poland)

### DIFF
--- a/drafts/2026-04.md
+++ b/drafts/2026-04.md
@@ -45,6 +45,9 @@ sooner events first, and should use the format:
 <brief description of event>
 -->
 
+### [RustMeet, 12-14 June 2026, Kraków, Poland](https://rustmeet.eu/en/)
+Second edition of RustMeet, the first Rust-dedicated programming conference in Poland. The three-day event features talks, workshops, and lightning talks, with online streaming available alongside the in-person programme.
+
 ## Publications
 <!--
 This section can be used to publicise papers, articles and blog posts published about scientific computing in Rust.


### PR DESCRIPTION
Adds [rustmeet.eu](https://rustmeet.eu/en/), a Rust conference in Kraków this June; second edition (to the inaugural meet that was conducted [last year](https://2025.rustmeet.eu/en/)).