### PR TITLE
add new release: cuda-oxide

### DIFF
--- a/drafts/2026-05.md
+++ b/drafts/2026-05.md
@@ -35,6 +35,12 @@ be sorted in alphabetical order and should use the format:
 ### [<library name> <release number>](<crates.io link>)
 <brief description of the library and its new features in this release>
 -->
+### [cuda-oxide v0.1.0](https://github.com/NVlabs/cuda-oxide/releases/tag/v0.1.0)
+
+cuda-oxide is an experimental rustc backend
+for compiling CUDA GPU kernels written in pure Rust to PTX.
+It supports single-source Rust GPU programs where host
+and device code live together and are built through `cargo oxide`.
 
 ## Events
 <!--


### PR DESCRIPTION
Closes #77 

Note: not a crates.io release. Also: there is crates.io hosted package that is not this `cuda-oxide`, but something older... Should we clarify this somewhat? @mscroggs
