### PR TITLE
`event`: Add SciPy India x Rust Delhi meetup

### DIFF
--- a/drafts/2026-06.md
+++ b/drafts/2026-06.md
@@ -45,6 +45,13 @@ sooner events first, and should use the format:
 <brief description of event>
 -->
 
+### [SciPy India x Rust Delhi Meetup, 22 August 2026, Noida, India](https://scipy.in/sci-py-rs/)
+
+[SciPy India](https://scipy.in/) and [Rust Delhi](https://rustdelhi.in/) are co-organising a technical meetup on
+scientific computing in Rust and Python. The sessions dig into real-world scientific problems and how people are
+solving them. The meetup runs from 2:00 PM to 5:00 PM at Essentia.dev in Noida, and the CFP is open to researchers,
+scientists, and developers (or anyone working at the intersection of Rust and Python) who want to present their work. You can submit a proposal or register at [scipy.in/sci-py-rs](https://scipy.in/sci-py-rs/).
+
 ## Publications
 <!--
 This section can be used to publicise papers, articles and blog posts published about scientific computing in Rust.


### PR DESCRIPTION
Adds the `SciPy India x Rust Delhi Meetup` to the "Events" section. It's a scientific computing in Rust and Python meetup co-organized by [SciPy India](https://scipy.in/) and [Rust Delhi](https://rustdelhi.in/), with RSVPs and the CFP currently [open](https://scipy.in/sci-py-rs/).

_CC: @agriyakhetarpal, @gswebspace_