### PR TITLE
Add cog3pio v0.1.0 release

### DIFF
--- a/drafts/2026-06.md
+++ b/drafts/2026-06.md
@@ -36,6 +36,18 @@ be sorted in alphabetical order and should use the format:
 <brief description of the library and its new features in this release>
 -->
 
+### [cog3pio v0.1.0](https://crates.io/crates/cog3pio)
+
+The [first minor release of cog3pio](https://cog3pio.readthedocs.io/en/v0.1.0/changelog/#010-2026-05-25) -
+a Rust/Python library for reading GeoTIFF raster data - is out! Main highlight is the
+ability to do GPU-accelerated decoding of TIFF data via bindings to nvTIFF (see
+[nvtiff-sys](https://crates.io/crates/nvtiff-sys) crate). The tensor data in CUDA memory
+can then be zero-copied across the Rust/Python boundary through the DLPack interchange
+protocol (using [dlpark](https://crates.io/crates/dlpark) crate). Read more about the
+technical details and background motivation in this
+[three-part blog series](https://weiji14.xyz/blog/geotiffs-to-gpus-part-3:-the-last-stage-via-dlpack-into-the-world/).
+
+
 ## Events
 <!--
 This section can be used to advertise events. Items should be sorted in date order, with


### PR DESCRIPTION
First minor release of cog3pio - a Rust/Python library for reading GeoTIFF raster data! Changelog at https://cog3pio.readthedocs.io/en/v0.1.0/changelog/#010-2026-05-25.