### PR TITLE
Add tenferro-rs help wanted item

### DIFF
--- a/drafts/2026-06.md
+++ b/drafts/2026-06.md
@@ -87,6 +87,20 @@ should be sorted in alphabetical order by project name and use the format:
 <brief description of the library and what kind of help you're interested in>
 -->
 
+### [tenferro-rs](https://github.com/tensor4all/tenferro-rs)
+
+`tenferro-rs` is a preview Rust-native differentiable tensor stack for scientific
+computing, with dense tensors, eager and traced automatic differentiation,
+NumPy/JAX-style einsum, linear algebra and FFT operation crates, and explicit
+CPU/CUDA/WebGPU backend control. The project is pre-1.0 and not yet published on
+crates.io, but it already emphasizes validation through AD reference oracles,
+finite-difference checks, runnable examples, CI, and reproducible benchmarks.
+
+We are looking for scientific-computing feedback and independent validation on
+real workloads: trying the examples and docs, reviewing AD and numerical
+behavior, checking backend limitations, and reviewing benchmark methodology in
+[`tenferro-benchmark`](https://github.com/tensor4all/tenferro-benchmark).
+
 ## Miscellaneous
 <!--
 Any items that do not fit into any other section can be added here.

--- a/drafts/2026-06.md
+++ b/drafts/2026-06.md
@@ -89,17 +89,23 @@ should be sorted in alphabetical order by project name and use the format:
 
 ### [tenferro-rs](https://github.com/tensor4all/tenferro-rs)
 
-`tenferro-rs` is a preview Rust-native differentiable tensor stack for scientific
-computing, with dense tensors, eager and traced automatic differentiation,
-NumPy/JAX-style einsum, linear algebra and FFT operation crates, and explicit
-CPU/CUDA/WebGPU backend control. The project is pre-1.0 and not yet published on
-crates.io, but it already emphasizes validation through AD reference oracles,
-finite-difference checks, runnable examples, CI, and reproducible benchmarks.
+`tenferro-rs` is a Rust-native differentiable tensor stack for scientific
+computing, with dense tensors, eager and traced automatic differentiation
+(`grad`/`vjp`/`jvp`), NumPy/JAX-style einsum, linear algebra and FFT operation
+crates, and explicit CPU/CUDA/WebGPU backend control. The first crates were
+published to crates.io as v0.1 this month (a preview ahead of a stable 1.0), and
+the project leans on systematic validation: AD reference oracles,
+finite-difference checks, runnable examples, CI, and reproducible benchmarks. It
+is already the engine under
+[`tensor4all-rs`](https://github.com/tensor4all/tensor4all-rs), a Rust
+tensor-network stack.
 
 We are looking for scientific-computing feedback and independent validation on
 real workloads: trying the examples and docs, reviewing AD and numerical
 behavior, checking backend limitations, and reviewing benchmark methodology in
-[`tenferro-benchmark`](https://github.com/tensor4all/tenferro-benchmark).
+[`tenferro-benchmark`](https://github.com/tensor4all/tenferro-benchmark). See the
+[launch post](https://tensor4all.org/blog/introducing-tenferro-rs/) for an
+overview.
 
 ## Miscellaneous
 <!--


### PR DESCRIPTION
Title: Add tenferro-rs help wanted item

Body:

Adds a Help wanted entry for tenferro-rs to the June 2026 draft.

The item frames tenferro-rs as a pre-1.0 preview project rather than a crates.io
release, highlights its oracle / finite-difference / CI / benchmark validation
posture, and asks for independent validation on real scientific-computing
workloads.
