### PR TITLE
added ET-SoC-1 crates.

### DIFF
--- a/drafts/2026-08.md
+++ b/drafts/2026-08.md
@@ -36,6 +36,24 @@ be sorted in alphabetical order and should use the format:
 <brief description of the library and its new features in this release>
 -->
 
+et-rs et-k-rs et-abi 0.2.0  
+
+Pure-Rust tooling for the Esperanto **ET-SoC-1** RISC-V accelerator: a host driver, a device-side kernel library, and the ABI they share.
+
+| Crate | Library | Side | Role |
+|-------|---------|------|------|
+| [`et-abi/`](et-abi/) | `et_abi` | shared (`no_std`) | Launch-argument structs plus shared constants (cache line, geometry), defined once so host and device cannot drift. |
+| [`et-rs/`](et-rs/) | `et_soc1` | host (`std`) | Loads kernels, launches them on shires, moves results over DMA, decodes trace buffers. Pure Rust, no vendor C++ runtime. |
+| [`et-k-rs/`](et-k-rs/) | `et_kernel` | device (`no_std`) | Library for writing ET-SoC-1 compute kernels in Rust, plus demo kernels. |
+
+`et-rs` and `et-abi` are host crates and form the workspace; `default-members`
+makes bare `cargo` commands operate on `et-rs`. `et-k-rs` cross-compiles to
+`riscv64imac` with its own target configuration, so it is excluded from the host
+workspace and built from its own directory. Both `et-rs` and `et-k-rs` depend on
+`et-abi`; neither depends on the other.
+
+There is also an example/tutorial on my GitHub to get you started: https://github.com/mathsDOTearth/test-et-rs
+
 ## Events
 <!--
 This section can be used to advertise events. Items should be sorted in date order, with


### PR DESCRIPTION
et-rs, et-k-rs and et-abi 0.2.0 crates for Rust tooling for the Esperanto ET-SoC-1 RISC-V accelerator card by Rich Neale (mathsDOTearth on GitHub).